### PR TITLE
Fix darwin clipboard

### DIFF
--- a/config/plug/mini/files.nix
+++ b/config/plug/mini/files.nix
@@ -69,8 +69,14 @@ in {
              local path = curr_entry.path
              -- Escape the path for shell command
              local escaped_path = vim.fn.fnameescape(path)
-             -- Build the osascript command to copy the file or directory to the clipboard
-             local cmd = string.format([[cat %s | wl-copy ]], escaped_path)
+             -- Choose platform-appropriate clipboard command
+             local is_macos = (vim.loop.os_uname().sysname == 'Darwin')
+             local cmd
+             if is_macos then
+               cmd = string.format([[cat %s | pbcopy ]], escaped_path)
+             else
+               cmd = string.format([[cat %s | wl-copy ]], escaped_path)
+             end
              local result = vim.fn.system(cmd)
              if vim.v.shell_error ~= 0 then
                vim.notify("Copy failed: " .. result, vim.log.levels.ERROR)

--- a/config/plug/utils/default.nix
+++ b/config/plug/utils/default.nix
@@ -1,26 +1,19 @@
 {
-  pkgs,
-  lib,
-  ...
-}: {
-  imports =
-    [
-      ./ufo.nix
-      ./helm.nix
-      ./leap.nix
-      ./trunk.nix
-      ./repeat.nix
-      ./sleuth.nix
-      ./comment.nix
-      ./spectre.nix
-      ./markview.nix
-      ./presence.nix
-      ./undotree.nix
-      ./toggleterm.nix
-      ./comment-box.nix
-      ./typst.nix
-    ]
-    ++ lib.optionals (!pkgs.stdenv.isDarwin) [
-      ./obsidian.nix
-    ];
+  imports = [
+    ./ufo.nix
+    ./helm.nix
+    ./leap.nix
+    ./trunk.nix
+    ./repeat.nix
+    ./sleuth.nix
+    ./comment.nix
+    ./spectre.nix
+    ./markview.nix
+    ./obsidian.nix
+    ./presence.nix
+    ./undotree.nix
+    ./toggleterm.nix
+    ./comment-box.nix
+    ./typst.nix
+  ];
 }

--- a/config/plug/utils/default.nix
+++ b/config/plug/utils/default.nix
@@ -1,19 +1,26 @@
 {
-  imports = [
-    ./ufo.nix
-    ./helm.nix
-    ./leap.nix
-    ./trunk.nix
-    ./repeat.nix
-    ./sleuth.nix
-    ./comment.nix
-    ./spectre.nix
-    ./markview.nix
-    ./obsidian.nix
-    ./presence.nix
-    ./undotree.nix
-    ./toggleterm.nix
-    ./comment-box.nix
-    ./typst.nix
-  ];
+  pkgs,
+  lib,
+  ...
+}: {
+  imports =
+    [
+      ./ufo.nix
+      ./helm.nix
+      ./leap.nix
+      ./trunk.nix
+      ./repeat.nix
+      ./sleuth.nix
+      ./comment.nix
+      ./spectre.nix
+      ./markview.nix
+      ./presence.nix
+      ./undotree.nix
+      ./toggleterm.nix
+      ./comment-box.nix
+      ./typst.nix
+    ]
+    ++ lib.optionals (!pkgs.stdenv.isDarwin) [
+      ./obsidian.nix
+    ];
 }

--- a/config/plug/utils/obsidian.nix
+++ b/config/plug/utils/obsidian.nix
@@ -2,6 +2,10 @@
   plugins.obsidian = {
     enable = true;
     settings = {
+      # Avoid requiring obsidian.pickers._fzf by selecting Telescope explicitly
+      picker = {
+        name = "telescope.nvim";
+      };
       completion = {
         min_chars = 2;
         nvim_cmp = false;

--- a/config/plug/utils/obsidian.nix
+++ b/config/plug/utils/obsidian.nix
@@ -1,4 +1,9 @@
 {
+  pkgs,
+  lib,
+  ...
+}:
+lib.mkIf (!pkgs.stdenv.isDarwin) {
   plugins.obsidian = {
     enable = true;
     settings = {

--- a/config/plug/utils/obsidian.nix
+++ b/config/plug/utils/obsidian.nix
@@ -2,10 +2,6 @@
   plugins.obsidian = {
     enable = true;
     settings = {
-      # Avoid requiring obsidian.pickers._fzf by selecting Telescope explicitly
-      picker = {
-        name = "telescope.nvim";
-      };
       completion = {
         min_chars = 2;
         nvim_cmp = false;


### PR DESCRIPTION
This pull request improves cross-platform clipboard support and adds configuration guardrails to ensure correct clipboard provider usage on macOS (Darwin) and non-Darwin systems. The most important changes are grouped below:

**Clipboard provider logic and platform checks:**

* Updated clipboard copy logic in `files.nix` to use `pbcopy` on macOS and `wl-copy` on other systems, ensuring correct clipboard integration per platform.
* In `sets.nix`, adjusted the `clipboard.providers` configuration to only enable `wl-copy` on non-Darwin systems, preventing incorrect provider usage on macOS.
* Added assertions in `sets.nix` to enforce that `wl-clipboard` is never enabled on Darwin and is always enabled on non-Darwin builds, providing clear error messages for misconfiguration.

**Platform-specific plugin configuration:**

* Modified the Obsidian plugin configuration to only enable on non-Darwin systems, preventing it from being set up on macOS.

**General code improvements:**

* Refactored argument lists in `sets.nix` for consistency and clarity.